### PR TITLE
Fix socket.bind() for nodejs 0.10 compatibility

### DIFF
--- a/lib/lifx/client.js
+++ b/lib/lifx/client.js
@@ -126,7 +126,7 @@ Client.prototype.init = function(options, callback) {
     this.emit('message', msg, rinfo);
   }.bind(this));
 
-  this.socket.bind(opts, function() {
+  this.socket.bind(opts.port, opts.address, function() {
     this.socket.setBroadcast(true);
     this.emit('listening');
     this.port = opts.port;


### PR DESCRIPTION
socket.bind(options) doesn't exist in node 0.10