### PR TITLE
Added globe ID to getState() return data

### DIFF
--- a/lib/lifx/light.js
+++ b/lib/lifx/light.js
@@ -122,6 +122,7 @@ Light.prototype.getState = function(callback) {
       msg.power = 1;
     }
     callback(null, {
+      id: msg.target,
       color: msg.color,
       power: msg.power,
       label: msg.label


### PR DESCRIPTION
The callback otherwise has no idea what light it has just been passed data for.

Is `id` satisfactory for that field? `target` is obviously used also.