### PR TITLE
Add try catch for reading incoming packets

### DIFF
--- a/lib/lifx/client.js
+++ b/lib/lifx/client.js
@@ -157,19 +157,25 @@ Client.prototype.init = function(options, callback) {
     if (this.debug) {
       console.log('DEBUG - ' + msg.toString('hex') + ' from ' + rinfo.address);
     }
+
     // Parse packet to object
     msg = Packet.toObject(msg);
 
-    // Convert type before emitting
-    var messageTypeName = _.result(_.find(Packet.typeList, {id: msg.type}), 'name');
-    if (messageTypeName !== undefined) {
-      msg.type = messageTypeName;
+    // Check if packet is read successfully
+    if (msg instanceof Error) {
+      console.error('LIFX Packet read error');
+      console.trace(msg);
+    } else {
+      // Convert type before emitting
+      var messageTypeName = _.result(_.find(Packet.typeList, {id: msg.type}), 'name');
+      if (messageTypeName !== undefined) {
+        msg.type = messageTypeName;
+      }
+      // Check for handlers of given message and rinfo
+      this.processMessageHandlers(msg, rinfo);
+
+      this.emit('message', msg, rinfo);
     }
-
-    // Check for handlers of given message and rinfo
-    this.processMessageHandlers(msg, rinfo);
-
-    this.emit('message', msg, rinfo);
   }.bind(this));
 
   this.socket.bind(opts.port, opts.address, function() {

--- a/lib/lifx/client.js
+++ b/lib/lifx/client.js
@@ -116,6 +116,8 @@ Client.prototype.init = function(options, callback) {
     throw new TypeError('LIFX Client broadcast option does only allow IPv4 address format');
   }
   this.broadcastAddress = opts.broadcast;
+  
+  if(opts.port >= 65536 || opts.port <= 0) opts.port = constants.LIFX_DEFAULT_PORT;
 
   if (!_.isArray(opts.lights)) {
     throw new TypeError('LIFX Client lights option must be an array');

--- a/lib/lifx/packet.js
+++ b/lib/lifx/packet.js
@@ -138,7 +138,13 @@ Packet.headerToObject = function(buf) {
 Packet.toObject = function(buf) {
   var obj = {};
 
-  obj = this.headerToObject(buf);
+  // Try to read header of packet
+  try {
+    obj = this.headerToObject(buf);
+  } catch (err) {
+    // If this fails return with error
+    return err;
+  }
 
   if (obj.type !== undefined) {
     var typeName = _.result(_.find(this.typeList, {id: obj.type}), 'name');


### PR DESCRIPTION
It seems there is quite often a packet coming in that could not be
read, it gave RangeError’s when trying to read it. By catching it we at
least prevent the code from crashing when such a packet comes in.
Further examination is needed to figure out what is “wrong” with these
incoming packets.