### PR TITLE
Fix scaling issues

### DIFF
--- a/lib/lifx/light.js
+++ b/lib/lifx/light.js
@@ -76,21 +76,21 @@ Light.prototype.color = function(hue, saturation, brightness, kelvin, duration, 
       constants.HSBK_MINIMUM_HUE + ' and ' + constants.HSBK_MAXIMUM_HUE
     );
   }
-  hue = Math.floor(hue / constants.HSBK_MAXIMUM_HUE * 65535);
+  hue = Math.round(hue / constants.HSBK_MAXIMUM_HUE * 65535);
 
   if (typeof saturation !== 'number' || saturation < constants.HSBK_MINIMUM_SATURATION || saturation > constants.HSBK_MAXIMUM_SATURATION) {
     throw new RangeError('LIFX light color method expects saturation to be a number between ' +
       constants.HSBK_MINIMUM_SATURATION + ' and ' + constants.HSBK_MAXIMUM_SATURATION
     );
   }
-  saturation = Math.floor(saturation / constants.HSBK_MAXIMUM_SATURATION * 65535);
+  saturation = Math.round(saturation / constants.HSBK_MAXIMUM_SATURATION * 65535);
 
   if (typeof brightness !== 'number' || brightness < constants.HSBK_MINIMUM_BRIGHTNESS || brightness > constants.HSBK_MAXIMUM_BRIGHTNESS) {
     throw new RangeError('LIFX light color method expects brightness to be a number between ' +
       constants.HSBK_MINIMUM_BRIGHTNESS + ' and ' + constants.HSBK_MAXIMUM_BRIGHTNESS
     );
   }
-  brightness = Math.floor(brightness / constants.HSBK_MAXIMUM_BRIGHTNESS * 65535);
+  brightness = Math.round(brightness / constants.HSBK_MAXIMUM_BRIGHTNESS * 65535);
 
   if (duration !== undefined && typeof duration !== 'number') {
     throw new RangeError('LIFX light color method expects duration to be a number');
@@ -127,9 +127,9 @@ Light.prototype.getState = function(callback) {
       return callback(err, null);
     }
     // Convert HSB to readable format
-    msg.color.hue = Math.floor(msg.color.hue * (constants.HSBK_MAXIMUM_HUE / 65535));
-    msg.color.saturation = Math.floor(msg.color.saturation * (constants.HSBK_MAXIMUM_SATURATION / 65535));
-    msg.color.brightness = Math.floor(msg.color.brightness * (constants.HSBK_MAXIMUM_BRIGHTNESS / 65535));
+    msg.color.hue = Math.round(msg.color.hue * (constants.HSBK_MAXIMUM_HUE / 65535));
+    msg.color.saturation = Math.round(msg.color.saturation * (constants.HSBK_MAXIMUM_SATURATION / 65535));
+    msg.color.brightness = Math.round(msg.color.brightness * (constants.HSBK_MAXIMUM_BRIGHTNESS / 65535));
     // Convert power to readable format
     if (msg.power === 65535) {
       msg.power = 1;


### PR DESCRIPTION
node-lifx has always had issues with scaling. Quite often the scaling with `node-lifx` doesn't match what the LIFX app is showing.

`Math.round` should be used instead of `Math.floor`.

For test purposes, set `Brightness` to `49%` and then read back the corresponding value and it will read `48%`.

This PR resolves that discrepancy.