### PR TITLE
add feature flags to LIFX_PRODUCT_IDS

### DIFF
--- a/lib/lifx/constants.js
+++ b/lib/lifx/constants.js
@@ -48,19 +48,19 @@ module.exports = {
 
   // Product ID values
   LIFX_PRODUCT_IDS: [
-    {id: 1, name: 'Original 1000'},
-    {id: 3, name: 'Color 650'},
-    {id: 10, name: 'White 800 (Low Voltage)'},
-    {id: 11, name: 'White 800 (High Voltage)'},
-    {id: 18, name: 'White 900 BR30 (Low Voltage)'},
-    {id: 19, name: 'White 900 BR30 (High Voltage)'},
-    {id: 20, name: 'Color 1000 BR30'},
-    {id: 22, name: 'Color 1000'},
-    {id: 27, name: 'LIFX A19'},
-    {id: 28, name: 'LIFX BR30'},
-    {id: 29, name: 'LIFX+ A19'},
-    {id: 30, name: 'LIFX+ BR30'},
-    {id: 31, name: 'LIFX Z'}
+    {id: 1, name: 'Original 1000', color: true, infrared: false, multizone: false},
+    {id: 3, name: 'Color 650', color: true, infrared: false, multizone: false},
+    {id: 10, name: 'White 800 (Low Voltage)', color: false, infrared: false, multizone: false},
+    {id: 11, name: 'White 800 (High Voltage)', color: false, infrared: false, multizone: false},
+    {id: 18, name: 'White 900 BR30 (Low Voltage)', color: false, infrared: false, multizone: false},
+    {id: 19, name: 'White 900 BR30 (High Voltage)', color: false, infrared: false, multizone: false},
+    {id: 20, name: 'Color 1000 BR30', color: true, infrared: false, multizone: false},
+    {id: 22, name: 'Color 1000', color: true, infrared: false, multizone: false},
+    {id: 27, name: 'LIFX A19', color: true, infrared: false, multizone: false},
+    {id: 28, name: 'LIFX BR30', color: true, infrared: false, multizone: false},
+    {id: 29, name: 'LIFX+ A19', color: true, infrared: true, multizone: false},
+    {id: 30, name: 'LIFX+ BR30', color: true, infrared: true, multizone: false},
+    {id: 31, name: 'LIFX Z', color: true, infrared: false, multizone: true}
   ],
 
   // Waveform values, order is important here


### PR DESCRIPTION
Add feature flags to prevent having to parse the product name to determine what features a bulb supports.