### PR TITLE
Light - add setWaveform method

### DIFF
--- a/lib/lifx/light.js
+++ b/lib/lifx/light.js
@@ -423,4 +423,82 @@ Light.prototype.getPower = function(callback) {
   }, sqnNumber);
 };
 
+/**
+ * Set Waveform
+ * @param {String} waveform            waveform name - ex: SAW, SINE, HALF_SINE, TRIANGLE, PULSE
+ * @param {Number} color.hue           color hue from 0 - 360 (in °)
+ * @param {Number} color.saturation    color saturation from 0 - 100 (in %)
+ * @param {Number} color.brightness    color brightness from 0 - 100 (in %)
+ * @param {Number} [color.kelvin=3500] color kelvin between 2500 and 9000
+ * @param {Number} period              Cycle time in ms
+ * @param {Number} cycles              Number of cycles
+ * @param {Number} skewRatio           Amount of time spent on the original color.
+ *                                     - 0 = Equal amount of time spent on both colors
+ *                                     - positive number - more time is spent on the original color
+ *                                     - negative number - more time is spent on the new color
+ * @param {Boolean} isTransient        Whether or not to transition back to the original color when cycles are done
+ * @param {Function} [callback]  called when light did receive message
+ */
+Light.prototype.setWaveform = function(waveform, color, period, cycles, skewRatio, isTransient, callback) {
+  var waveformID = constants.LIGHT_WAVEFORMS.indexOf(waveform);
+
+  if (typeof waveform !== 'string' || waveformID === -1) {
+    throw new TypeError('LIFX light setWaveform method expects waveform to be one of the following: ' +
+      constants.LIGHT_WAVEFORMS.join(', ')
+    );
+  }
+
+  if (typeof period !== 'number') {
+    throw new TypeError('LIFX light setWaveform method expects period to be a number');
+  }
+
+  if (typeof cycles !== 'number') {
+    throw new TypeError('LIFX light setWaveform method expects cycles to be a number');
+  }
+
+  if (typeof skewRatio !== 'number') {
+    throw new TypeError('LIFX light setWaveform method expects skewRatio to be a number');
+  }
+
+  if (typeof isTransient !== 'boolean') {
+    throw new TypeError('LIFX light setWaveform method expects isTransient to be a boolean');
+  }
+
+  if (typeof color.hue !== 'number' || color.hue < constants.HSBK_MINIMUM_HUE || color.hue > constants.HSBK_MAXIMUM_HUE) {
+    throw new RangeError('LIFX light setWaveform method expects color.hue to be a number between ' +
+      constants.HSBK_MINIMUM_HUE + ' and ' + constants.HSBK_MAXIMUM_HUE
+    );
+  }
+  color.hue = Math.round(color.hue / constants.HSBK_MAXIMUM_HUE * 65535);
+
+  if (typeof color.saturation !== 'number' || color.saturation < constants.HSBK_MINIMUM_SATURATION || color.saturation > constants.HSBK_MAXIMUM_SATURATION) {
+    throw new RangeError('LIFX light setWaveform method expects color.saturation to be a number between ' +
+      constants.HSBK_MINIMUM_SATURATION + ' and ' + constants.HSBK_MAXIMUM_SATURATION
+    );
+  }
+  color.saturation = Math.round(color.saturation / constants.HSBK_MAXIMUM_SATURATION * 65535);
+
+  if (typeof color.brightness !== 'number' || color.brightness < constants.HSBK_MINIMUM_BRIGHTNESS || color.brightness > constants.HSBK_MAXIMUM_BRIGHTNESS) {
+    throw new RangeError('LIFX light setWaveform method expects color.brightness to be a number between ' +
+      constants.HSBK_MINIMUM_BRIGHTNESS + ' and ' + constants.HSBK_MAXIMUM_BRIGHTNESS
+    );
+  }
+  color.brightness = Math.round(color.brightness / constants.HSBK_MAXIMUM_BRIGHTNESS * 65535);
+
+  if (callback !== undefined && typeof callback !== 'function') {
+    throw new TypeError('LIFX light setWaveform method expects callback to be a function');
+  }
+
+  var packetObj = packet.create('setWaveform', {
+    isTransient: isTransient,
+    color: color,
+    period: period,
+    cycles: cycles,
+    skewRatio: skewRatio,
+    waveform: waveformID
+  }, this.client.source);
+  packetObj.target = this.id;
+  this.client.send(packetObj, callback);
+};
+
 exports.Light = Light;


### PR DESCRIPTION
Hi,
I gave a go at implementing the setWaveform method you mentioned in #21 

Usage:
```js
light.setWaveform(
    'SAW', // waveform type
    { hue: 150, saturation: 80, brightness: 60, kelvin: 3500}, // color
    200, // period
    5, // cycles
    0, // skewRatio
    true // isTransient
);
```