### PR TITLE
Bind to a random port by default

### DIFF
--- a/lib/lifx/client.js
+++ b/lib/lifx/client.js
@@ -67,7 +67,7 @@ util.inherits(Client, EventEmitter);
 Client.prototype.init = function(options, callback) {
   var defaults = {
     address: '0.0.0.0',
-    port: constants.LIFX_DEFAULT_PORT,
+    port: 0,
     debug: false,
     lightOfflineTolerance: 3,
     messageHandlerTimeout: 45000,
@@ -85,8 +85,8 @@ Client.prototype.init = function(options, callback) {
 
   if (typeof opts.port !== 'number') {
     throw new TypeError('LIFX Client port option must be a number');
-  } else if (opts.port > 65535 || opts.port < 1) {
-    throw new RangeError('LIFX Client port option must be between 1 and 65535');
+  } else if (opts.port > 65535 || opts.port < 0) {
+    throw new RangeError('LIFX Client port option must be between 0 and 65535');
   }
 
   if (typeof opts.debug !== 'boolean') {

--- a/lib/lifx/client.js
+++ b/lib/lifx/client.js
@@ -61,6 +61,7 @@ util.inherits(Client, EventEmitter);
  * @param {Boolean} [options.startDiscovery] Weather to start discovery after initialization or not
  * @param {Array} [options.lights] Pre set list of ip addresses of known addressable lights
  * @param {String} [options.broadcast] The broadcast address to use for light discovery
+ * @param {Number} [options.sendPort] The port to send messages to
  * @param {Function} [callback] Called after initialation
  */
 Client.prototype.init = function(options, callback) {
@@ -74,6 +75,7 @@ Client.prototype.init = function(options, callback) {
     startDiscovery: true,
     lights: [],
     broadcast: '255.255.255.255',
+    sendPort: constants.LIFX_DEFAULT_PORT,
     resendPacketDelay: 150,
     resendMaxTimes: 3
   };
@@ -118,6 +120,13 @@ Client.prototype.init = function(options, callback) {
     throw new TypeError('LIFX Client broadcast option does only allow IPv4 address format');
   }
   this.broadcastAddress = opts.broadcast;
+
+  if (typeof opts.sendPort !== 'number') {
+    throw new TypeError('LIFX Client sendPort option must be a number');
+  } else if (opts.sendPort > 65535 || opts.sendPort < 1) {
+    throw new RangeError('LIFX Client sendPort option must be between 1 and 65535');
+  }
+  this.sendPort = opts.sendPort;
 
   if (!_.isArray(opts.lights)) {
     throw new TypeError('LIFX Client lights option must be an array');
@@ -225,7 +234,7 @@ Client.prototype.sendingProcess = function() {
       msg.address = this.broadcastAddress;
     }
     if (msg.transactionType === constants.PACKET_TRANSACTION_TYPES.ONE_WAY) {
-      this.socket.send(msg.data, 0, msg.data.length, this.port, msg.address);
+      this.socket.send(msg.data, 0, msg.data.length, this.sendPort, msg.address);
       /* istanbul ignore if  */
       if (this.debug) {
         console.log('DEBUG - ' + msg.data.toString('hex') + ' to ' + msg.address);
@@ -233,7 +242,7 @@ Client.prototype.sendingProcess = function() {
     } else if (msg.transactionType === constants.PACKET_TRANSACTION_TYPES.REQUEST_RESPONSE) {
       if (msg.timesSent < this.resendMaxTimes) {
         if (Date.now() > (msg.timeLastSent + this.resendPacketDelay)) {
-          this.socket.send(msg.data, 0, msg.data.length, this.port, msg.address);
+          this.socket.send(msg.data, 0, msg.data.length, this.sendPort, msg.address);
           msg.timesSent += 1;
           msg.timeLastSent = Date.now();
           /* istanbul ignore if  */

--- a/test/unit/client-test.js
+++ b/test/unit/client-test.js
@@ -55,7 +55,8 @@ suite('Client', () => {
       resendPacketDelay: 200,
       resendMaxTimes: 2,
       lights: ['192.168.0.100'],
-      broadcast: '192.168.0.255'
+      broadcast: '192.168.0.255',
+      sendPort: 65534
     }, () => {
       assert.equal(client.address().address, '127.0.0.1');
       assert.equal(client.address().port, 65535);
@@ -65,6 +66,7 @@ suite('Client', () => {
       assert.equal(client.resendPacketDelay, 200);
       assert.equal(client.resendMaxTimes, 2);
       assert.equal(client.broadcastAddress, '192.168.0.255');
+      assert.equal(client.sendPort, 65534);
       done();
     });
   });
@@ -129,6 +131,18 @@ suite('Client', () => {
     assert.throw(() => {
       client.init({broadcast: ['255.255.255.255']});
     }, TypeError);
+
+    assert.throw(() => {
+      client.init({sendPort: '57500'});
+    }, TypeError);
+
+    assert.throw(() => {
+      client.init({sendPort: 0});
+    }, RangeError);
+
+    assert.throw(() => {
+      client.init({sendPort: 65536});
+    }, RangeError);
   });
 
   test('inits with random source by default', (done) => {

--- a/test/unit/client-test.js
+++ b/test/unit/client-test.js
@@ -77,7 +77,7 @@ suite('Client', () => {
     }, TypeError);
 
     assert.throw(() => {
-      client.init({port: 0});
+      client.init({port: -1});
     }, RangeError);
 
     assert.throw(() => {
@@ -143,6 +143,20 @@ suite('Client', () => {
     assert.throw(() => {
       client.init({sendPort: 65536});
     }, RangeError);
+  });
+
+  test('inits with random bind port by default', (done) => {
+    client.init({
+      startDiscovery: false
+    }, () => {
+      assert.equal(client.address().address, '0.0.0.0');
+      assert.notEqual(client.address().port, constants.LIFX_DEFAULT_PORT);
+      assert.isAtLeast(client.address().port, 1024);
+      assert.isAtMost(client.address().port, 65535);
+      assert.equal(client.port, 0);
+      assert.equal(client.sendPort, constants.LIFX_DEFAULT_PORT);
+      done();
+    });
   });
 
   test('inits with random source by default', (done) => {
@@ -539,6 +553,7 @@ suite('Client', () => {
       const packetObj = packet.create('setPower', {level: 65535}, client.source);
 
       client.init({
+        port: constants.LIFX_DEFAULT_PORT,
         startDiscovery: false
       }, () => {
         client.socket.on('message', packetSendCallback);
@@ -566,6 +581,7 @@ suite('Client', () => {
       const packetObj = packet.create('setPower', {level: 65535}, client.source);
 
       client.init({
+        port: constants.LIFX_DEFAULT_PORT,
         startDiscovery: false
       }, () => {
         client.socket.on('message', packetSendCallback);


### PR DESCRIPTION
This PR splits the bind port configuration option from target port address option and changes the default bind port to be random. This permits multiple instances of `node-lifx` to be used without having to bind to seperate interfaces.