### PR TITLE
Add methods to retrieve uptime and reboot bulb

### DIFF
--- a/lib/lifx/light.js
+++ b/lib/lifx/light.js
@@ -306,6 +306,20 @@ Light.prototype.getUptime = function(callback) {
 };
 
 /**
+ * Reboots the light
+ * @param {Function} callback called when light did receive message
+ */
+Light.prototype.reboot = function(callback) {
+  if (typeof callback !== 'function') {
+    throw new TypeError('LIFX light reboot method expects callback to be a function');
+  }
+  var packetObj = packet.create('rebootRequest', {}, this.client.source);
+  packetObj.target = this.id;
+  var sqnNumber = this.client.send(packetObj);
+  this.client.addMessageHandler('rebootResponse', callback, sqnNumber);
+};
+
+/**
  * Requests used version from the microcontroller unit of the light
  * @param {Function} callback a function to accept the data
  */

--- a/lib/lifx/light.js
+++ b/lib/lifx/light.js
@@ -286,6 +286,26 @@ Light.prototype.getHardwareVersion = function(callback) {
 };
 
 /**
+ * Requests uptime from the light
+ * @param {Function} callback a function to accept the data with error and
+ *                   message as parameters
+ */
+Light.prototype.getUptime = function(callback) {
+  if (typeof callback !== 'function') {
+    throw new TypeError('LIFX light getUptime method expects callback to be a function');
+  }
+  var packetObj = packet.create('getInfo', {}, this.client.source);
+  packetObj.target = this.id;
+  var sqnNumber = this.client.send(packetObj);
+  this.client.addMessageHandler('stateInfo', function(err, msg) {
+    if (err) {
+      return callback(err, null);
+    }
+    callback(null, msg.uptime);
+  }, sqnNumber);
+};
+
+/**
  * Requests used version from the microcontroller unit of the light
  * @param {Function} callback a function to accept the data
  */

--- a/lib/lifx/packet.js
+++ b/lib/lifx/packet.js
@@ -48,6 +48,8 @@ Packet.typeList = [
   {id: 33, name: 'stateVersion'},
   {id: 34, name: 'getInfo'},
   {id: 35, name: 'stateInfo'},
+  {id: 38, name: 'rebootRequest'},
+  {id: 43, name: 'rebootResponse'},
   {id: 45, name: 'acknowledgement'},
   {id: 48, name: 'getLocation'},
   {id: 50, name: 'stateLocation'},

--- a/lib/lifx/packet.js
+++ b/lib/lifx/packet.js
@@ -46,6 +46,8 @@ Packet.typeList = [
   {id: 25, name: 'stateLabel'},
   {id: 32, name: 'getVersion'},
   {id: 33, name: 'stateVersion'},
+  {id: 34, name: 'getInfo'},
+  {id: 35, name: 'stateInfo'},
   {id: 45, name: 'acknowledgement'},
   {id: 48, name: 'getLocation'},
   {id: 50, name: 'stateLocation'},

--- a/lib/lifx/packets/getInfo.js
+++ b/lib/lifx/packets/getInfo.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var Packet = {
+  size: 0
+};
+
+module.exports = Packet;

--- a/lib/lifx/packets/index.js
+++ b/lib/lifx/packets/index.js
@@ -32,6 +32,9 @@ packets.stateVersion = require('./stateVersion');
 packets.getInfo = require('./getInfo');
 packets.stateInfo = require('./stateInfo');
 
+packets.rebootRequest = require('./rebootRequest');
+packets.rebootResponse = require('./rebootResponse');
+
 packets.acknowledgement = require('./acknowledgement');
 
 packets.echoRequest = require('./echoRequest');

--- a/lib/lifx/packets/index.js
+++ b/lib/lifx/packets/index.js
@@ -29,6 +29,9 @@ packets.statePower = require('./statePower');
 packets.getVersion = require('./getVersion');
 packets.stateVersion = require('./stateVersion');
 
+packets.getInfo = require('./getInfo');
+packets.stateInfo = require('./stateInfo');
+
 packets.acknowledgement = require('./acknowledgement');
 
 packets.echoRequest = require('./echoRequest');

--- a/lib/lifx/packets/rebootRequest.js
+++ b/lib/lifx/packets/rebootRequest.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var Packet = {
+  size: 0
+};
+
+module.exports = Packet;

--- a/lib/lifx/packets/rebootResponse.js
+++ b/lib/lifx/packets/rebootResponse.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var Packet = {
+  size: 0
+};
+
+module.exports = Packet;

--- a/lib/lifx/packets/stateInfo.js
+++ b/lib/lifx/packets/stateInfo.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var utils = require('../../lifx').utils;
+
+var Packet = {
+  size: 24
+};
+
+Packet.parseNanoseconds = function(buf) {
+  if (buf.length !== 8) {
+    throw new Error('Invalid length given for nanoseconds field');
+  }
+
+  var low = buf.readUInt32LE(0);
+  var high = buf.readUInt32LE(4);
+
+  return (high * 2**32 + low) / 1.0E9;
+};
+
+/**
+ * Converts packet specific data from a buffer to an object
+ * @param  {Buffer} buf Buffer containing only packet specific data no header
+ * @return {Object}     Information contained in packet
+ */
+Packet.toObject = function(buf) {
+  var obj = {};
+  var offset = 0;
+
+  // Check length
+  if (buf.length !== this.size) {
+    throw new Error('Invalid length given for stateInfo LIFX packet');
+  }
+
+  obj.time = this.parseNanoseconds(utils.readUInt64LE(buf, offset));
+  offset += 8;
+
+  obj.uptime = this.parseNanoseconds(utils.readUInt64LE(buf, offset));
+  offset += 8;
+
+  obj.downtime = this.parseNanoseconds(utils.readUInt64LE(buf, offset));
+  offset += 8;
+
+  return obj;
+};
+
+module.exports = Packet;


### PR DESCRIPTION
Tested with LIFX Original.

I use these to monitor device uptime and reboot the bulb when connection to the cloud is lost and does not automatically reconnect.

The uptime call is officially documented. The reboot request packet was found via the [no longer supported Ruby gem](https://github.com/LIFX/lifx-gem/blob/a33fe79a56e73781fd13e32226dae09b1c1e141f/lib/lifx/protocol/type.rb#L104). The reboot response packet was found via a packet capture.