### PR TITLE
minimize lodash imports. reduces webpack size by half.

### DIFF
--- a/lib/lifx/client.js
+++ b/lib/lifx/client.js
@@ -3,7 +3,14 @@
 var util = require('util');
 var dgram = require('dgram');
 var EventEmitter = require('eventemitter3');
-var _ = require('lodash');
+var _ = {
+  result: require('lodash/result'),
+  isArray: require('lodash/isArray'),
+  defaults: require('lodash/defaults'),
+  find: require('lodash/find'),
+  bind: require('lodash/bind'),
+  forEach: require('lodash/forEach')
+};
 var Packet = require('../lifx').packet;
 var Light = require('../lifx').Light;
 var constants = require('../lifx').constants;

--- a/lib/lifx/light.js
+++ b/lib/lifx/light.js
@@ -3,7 +3,10 @@
 var packet = require('../lifx').packet;
 var constants = require('../lifx').constants;
 var utils = require('../lifx').utils;
-var _ = require('lodash');
+var _ = {
+  pick: require('lodash/pick'),
+  assign: require('lodash/assign')
+};
 
 /**
  * A representation of a light bulb

--- a/lib/lifx/packet.js
+++ b/lib/lifx/packet.js
@@ -3,7 +3,12 @@
 var constants = require('../lifx').constants;
 var packets = require('./packets');
 var utils = require('../lifx').utils;
-var _ = require('lodash');
+var _ = {
+  result: require('lodash/result'),
+  find: require('lodash/find'),
+  extend: require('lodash/extend'),
+  assign: require('lodash/assign')
+};
 
 /*
   Package headers 36 bit in total consisting of

--- a/lib/lifx/packets/stateVersion.js
+++ b/lib/lifx/packets/stateVersion.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var _ = require('lodash');
+var _ = {
+  find: require('lodash/find')
+};
 var constants = require('../../lifx').constants;
 
 var Packet = {

--- a/lib/lifx/products.json
+++ b/lib/lifx/products.json
@@ -112,12 +112,152 @@
 				}
 			},
 			{
+				"pid": 36,
+				"name": "LIFX Downlight",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
+				"pid": 37,
+				"name": "LIFX Downlight",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
+				"pid": 38,
+				"name": "LIFX Beam",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": true,
+					"chain": false
+				}
+			},
+			{
+				"pid": 43,
+				"name": "LIFX A19",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
+				"pid": 44,
+				"name": "LIFX BR30",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
+				"pid": 45,
+				"name": "LIFX+ A19",
+				"features": {
+					"color": true,
+					"infrared": true,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
+				"pid": 46,
+				"name": "LIFX+ BR30",
+				"features": {
+					"color": true,
+					"infrared": true,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
 				"pid": 49,
 				"name": "LIFX Mini Color",
 				"features": {
 					"color": true,
 					"infrared": false,
 					"multizone": true
+				}
+			},
+			{
+				"pid": 50,
+				"name": "LIFX Mini Day and Dusk",
+				"features": {
+					"color": false,
+					"infrared": false,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
+				"pid": 51,
+				"name": "LIFX Mini White",
+				"features": {
+					"color": false,
+					"infrared": false,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
+				"pid": 52,
+				"name": "LIFX GU10",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
+				"pid": 55,
+				"name": "LIFX Tile",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false,
+					"chain": true
+				}
+			},
+			{
+				"pid": 59,
+				"name": "LIFX Mini Color",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
+				"pid": 60,
+				"name": "LIFX Mini Day and Dusk",
+				"features": {
+					"color": false,
+					"infrared": false,
+					"multizone": false,
+					"chain": false
+				}
+			},
+			{
+				"pid": 61,
+				"name": "LIFX Mini White",
+				"features": {
+					"color": false,
+					"infrared": false,
+					"multizone": false,
+					"chain": false
 				}
 			}
 		]


### PR DESCRIPTION
Thanks for the great project.

I'm currently using it in a non-node environment with minimal shimming on dgram. Everything works, but the webpack size is quite large. It can be reduced by nearly half by only importing what is necessary from lodash (which fairly large). My particular webpack with these changes went from 880kb to 450kb.

I've also updated it with a more exhaustive list of products from here:
https://github.com/futomi/node-lifx-lan/blob/master/lib/products.json


Lodash Doc:
https://www.blazemeter.com/blog/the-correct-way-to-import-lodash-libraries-a-benchmark